### PR TITLE
Revert "Bump nexus-staging-maven-plugin from 1.6.8 to 1.6.10"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,7 +221,7 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.10</version>
+                        <version>1.6.8</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>


### PR DESCRIPTION
Reverts drasyl-overlay/netty-tun#7

Reason: https://issues.sonatype.org/browse/NEXUS-31214?focusedCommentId=1140935&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-1140935