### PR TITLE
Add option to adjust MTU of the TUN device

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ finally {
 }
 ```
 
+### IP Address/Netmask
+
 You can now assign an IP address and netmask to the created network interface (you can query the
 actual interface name by
 calling [Channel#localAddress()](https://netty.io/4.1/api/io/netty/channel/Channel.html#localAddress--)):
@@ -43,4 +45,15 @@ New-NetIPAddress -InterfaceIndex $InterfaceIndex -IPAddress 10.10.10.10 -PrefixL
 
 # to allow peers access local services, you may mark the tun network as "private"
 Set-NetConnectionProfile -InterfaceIndex $InterfaceIndex -NetworkCategory "Private"
+```
+
+## MTU
+
+The MTU size of the created network interface is by default 1500 on macOS/Linux and 65535 on Windows.
+
+On macOS/Linux is can be adjusted by passing the channel option [`TunChannelOption.TUN_MTU`](https://github.com/drasyl-overlay/netty-tun/blob/master/src/main/java/org/drasyl/channel/tun/TunChannelOption.java) to the [`Bootstrap`](https://netty.io/4.1/api/io/netty/bootstrap/Bootstrap.html) object.
+
+On Windows you have to use the following command:
+```powershell
+netsh interface ipv4 set subinterface tun0 mtu=1234 store=active
 ```

--- a/src/main/java/org/drasyl/channel/tun/DefaultTunChannelConfig.java
+++ b/src/main/java/org/drasyl/channel/tun/DefaultTunChannelConfig.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2021-2022 Heiko Bornholdt and Kevin Röbert
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ * OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.drasyl.channel.tun;
+
+import io.netty.channel.ChannelOption;
+import io.netty.channel.DefaultChannelConfig;
+
+import static org.drasyl.channel.tun.TunChannelOption.TUN_MTU;
+
+/**
+ * The default {@link TunChannelConfig} implementation.
+ */
+public class DefaultTunChannelConfig extends DefaultChannelConfig implements TunChannelConfig {
+    private int mtu;
+
+    public DefaultTunChannelConfig(final TunChannel channel) {
+        super(channel);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T getOption(final ChannelOption<T> option) {
+        if (option == TUN_MTU) {
+            return (T) Integer.valueOf(getMtu());
+        }
+        return super.getOption(option);
+    }
+
+    @Override
+    public <T> boolean setOption(final ChannelOption<T> option, final T value) {
+        if (!super.setOption(option, value)) {
+            if (option == TUN_MTU) {
+                setMtu((Integer) value);
+            }
+            else {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public int getMtu() {
+        return mtu;
+    }
+
+    @Override
+    public TunChannelConfig setMtu(final int mtu) {
+        if (mtu < 0) {
+            throw new IllegalArgumentException("mtu must be non-negative.");
+        }
+        this.mtu = mtu;
+        return null;
+    }
+}

--- a/src/main/java/org/drasyl/channel/tun/TunChannel.java
+++ b/src/main/java/org/drasyl/channel/tun/TunChannel.java
@@ -113,13 +113,13 @@ public class TunChannel extends AbstractChannel {
     @Override
     protected void doBind(final SocketAddress localAddress) throws Exception {
         if (PlatformDependent.isOsx()) {
-            device = DarwinTunDevice.open(((TunAddress) localAddress).ifName());
+            device = DarwinTunDevice.open(((TunAddress) localAddress).ifName(), 0);
         }
         else if (PlatformDependent.isWindows()) {
             device = WindowsTunDevice.open(((TunAddress) localAddress).ifName());
         }
         else {
-            device = LinuxTunDevice.open(((TunAddress) localAddress).ifName());
+            device = LinuxTunDevice.open(((TunAddress) localAddress).ifName(), 0);
         }
     }
 

--- a/src/main/java/org/drasyl/channel/tun/TunChannelConfig.java
+++ b/src/main/java/org/drasyl/channel/tun/TunChannelConfig.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021-2022 Heiko Bornholdt and Kevin Röbert
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ * OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.drasyl.channel.tun;
+
+import io.netty.channel.ChannelConfig;
+
+/**
+ * A {@link ChannelConfig} for a {@link TunChannel}.
+ *
+ * <h3>Available options</h3>
+ * <p>
+ * In addition to the options provided by {@link ChannelConfig}, {@link TunChannelConfig} allows the
+ * following options in the option map:
+ *
+ * <table border="1" cellspacing="0" cellpadding="6">
+ * <tr>
+ * <th>Name</th><th>Associated setter method</th>
+ * </tr><tr>
+ * <td>{@link TunChannelOption#TUN_MTU}</td><td>{@link #setMtu(int)}</td>
+ * </tr>
+ * </table>
+ */
+public interface TunChannelConfig extends ChannelConfig {
+    /**
+     * Gets the {@link TunChannelOption#TUN_MTU} option.
+     */
+    int getMtu();
+
+    /**
+     * Sets the {@link TunChannelOption#TUN_MTU} option.
+     */
+    TunChannelConfig setMtu(int mtu);
+}

--- a/src/main/java/org/drasyl/channel/tun/TunChannelOption.java
+++ b/src/main/java/org/drasyl/channel/tun/TunChannelOption.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021-2022 Heiko Bornholdt and Kevin Röbert
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ * OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.drasyl.channel.tun;
+
+import io.netty.channel.ChannelOption;
+
+/**
+ * Provides {@link ChannelOption}s for {@link TunChannel}s.
+ */
+public final class TunChannelOption<T> extends ChannelOption<T> {
+    /**
+     * Defines MTU for the created tun device (not supported on windows).
+     */
+    public static final ChannelOption<Integer> TUN_MTU = valueOf("TUN_MTU");
+
+    @SuppressWarnings({ "java:S1144", "java:S1874" })
+    private TunChannelOption(final String name) {
+        super(name);
+    }
+}

--- a/src/main/java/org/drasyl/channel/tun/jna/darwin/Ioctl.java
+++ b/src/main/java/org/drasyl/channel/tun/jna/darwin/Ioctl.java
@@ -30,6 +30,8 @@ import com.sun.jna.NativeLong;
 final class Ioctl {
     // get MTU size
     public static final NativeLong SIOCGIFMTU = new NativeLong(0xc0206933L);
+    // set MTU size
+    public static final NativeLong SIOCSIFMTU = new NativeLong(0x80206934L);
 
     private Ioctl() {
         // JNA mapping

--- a/src/main/java/org/drasyl/channel/tun/jna/linux/LinuxTunDevice.java
+++ b/src/main/java/org/drasyl/channel/tun/jna/linux/LinuxTunDevice.java
@@ -90,7 +90,6 @@ public final class LinuxTunDevice extends AbstractTunDevice {
         final int s = socket(AF_INET, SOCK_DGRAM, 0);
         if (mtu != 0) {
             // set mtu
-            System.out.println("set = " + mtu);
             final Ifreq ifreq2 = new Ifreq(deviceName, mtu);
             ioctl(s, SIOCSIFMTU, ifreq2);
             mtu = ifreq2.ifr_ifru.ifru_mtu;

--- a/src/main/java/org/drasyl/channel/tun/jna/linux/Sockios.java
+++ b/src/main/java/org/drasyl/channel/tun/jna/linux/Sockios.java
@@ -29,6 +29,8 @@ import com.sun.jna.NativeLong;
 final class Sockios {
     // get MTU size
     public static final NativeLong SIOCGIFMTU = new NativeLong(0x8921L);
+    // set MTU size
+    public static final NativeLong SIOCSIFMTU = new NativeLong(0x8922L);
 
     private Sockios() {
         // JNA mapping

--- a/src/main/java/org/drasyl/channel/tun/jna/shared/If.java
+++ b/src/main/java/org/drasyl/channel/tun/jna/shared/If.java
@@ -62,6 +62,16 @@ public final class If {
             this.ifr_ifru.ifru_flags = flags;
         }
 
+        public Ifreq(final String ifr_name, final int mtu) {
+            this.ifr_name = new byte[IFNAMSIZ];
+            if (ifr_name != null) {
+                final byte[] bytes = ifr_name.getBytes(US_ASCII);
+                System.arraycopy(bytes, 0, this.ifr_name, 0, bytes.length);
+            }
+            this.ifr_ifru.setType("ifru_mtu");
+            this.ifr_ifru.ifru_mtu = mtu;
+        }
+
         @SuppressWarnings({ "java:S116", "java:S1104", "java:S2160" })
         public static class FfrIfru extends Union {
             public short ifru_flags;


### PR DESCRIPTION
This MR adds a channel option for adjusting the MTU size of the created TUN device.

Example:
```java
final Bootstrap b = new Bootstrap()
        .channel(TunChannel.class)
        .option(TunChannelOption.TUN_MTU, 1234)
        .group(new NioEventLoopGroup(1))
        .handler(new ChannelInitializer<>() {
            @Override
            protected void initChannel(final Channel ch) {
                ...
            }
        });
final Channel ch = b.bind(new TunAddress(name)).syncUninterruptibly().channel();
ch.closeFuture().syncUninterruptibly();
```

Currently, this option is not supported on Windows as the MTU size [is hard-coded into wintun](https://git.zx2c4.com/wintun/tree/api/wintun.h#n203). Modifying this file to our needs is not possible, as we then need to provide a new valid signature. Without a valid signature, Windows will not load the driver.

Windows users can adjust the MUT size with the following command: `netsh interface ipv4 set subinterface tun0 mtu=1234 store=active`